### PR TITLE
Add title(s) and author(s) and nosearch param to /scan_cover and /scan_shelf endpoints

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -205,6 +205,11 @@ be.
 Expects a request with a body that is in *binary*, which represents an image.
 The image can either be JPG or PNG.
 
+It takes one optional parameter:
+
+- `"nosearch"`: If given any value, then Google Books will not be used. This
+  makes the `"books"` attribute an empty array.
+
 The response JSON will contain two additional fields:
 
 - `"title"`: Title recognized from the image.
@@ -219,6 +224,11 @@ the image.
 
 Expects a request with a body that is in *binary*, which represents an image.
 The image can either be JPG or PNG.
+
+It takes one optional parameter:
+
+- `"nosearch"`: If given any value, then Google Books will not be used. This
+  makes the `"books"` attribute an empty array.
 
 The response JSON will contain two additional fields:
 

--- a/server/README.md
+++ b/server/README.md
@@ -125,7 +125,8 @@ bad requests result in a `400: BAD REQUEST` status.
 
 The body of both `200` and `400` responses are in JSON.
 
-A successful (`200`) response is in the following format:
+A successful (`200`) response is in the format below. Additional fields might
+be added to the body of the request, but these fields are guaranteed.
 
 ```
 {
@@ -204,6 +205,13 @@ be.
 Expects a request with a body that is in *binary*, which represents an image.
 The image can either be JPG or PNG.
 
+The response JSON will contain two additional fields:
+
+- `"title"`: Title recognized from the image.
+- `"author"`: Author recognized from the image.
+
+These two fields are strings.
+
 ## POST /books/scan_shelf
 
 Scans the given image of a bookshelf and returns the books it thinks are in
@@ -211,6 +219,13 @@ the image.
 
 Expects a request with a body that is in *binary*, which represents an image.
 The image can either be JPG or PNG.
+
+The response JSON will contain two additional fields:
+
+- `"titles"`: Titles recognized from the image.
+- `"authors"`: Authors recognized from the image.
+
+These two fields are parallel arrays of strings.
 
 ## GET /books/search
 

--- a/server/scripts/scan_cover.py
+++ b/server/scripts/scan_cover.py
@@ -18,7 +18,7 @@ def main(
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
     image = cv.imread(str(image_path))
-    books = scan_cover(image)
+    books, _ = scan_cover(image)
     for book in books:
         print(f"{book.title}")
         print(f"- {book.authors}")

--- a/server/scripts/scan_shelf.py
+++ b/server/scripts/scan_shelf.py
@@ -23,7 +23,7 @@ def main(image_path: cy.types.ResolvedExistingFile) -> None:
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
     image = cv.imread(str(image_path))
-    results = scan_shelf(image)
+    results, _ = scan_shelf(image)
     # pprint(results)
 
     pprint([len(result) for result in results])

--- a/server/tabby_server/__init__.py
+++ b/server/tabby_server/__init__.py
@@ -1,3 +1,4 @@
+from logging.config import dictConfig
 from flask import Flask
 from http import HTTPStatus
 from tabby_server.api import books
@@ -43,3 +44,23 @@ def hello_world():
 @app.route("/api/test", methods=["POST"])
 def test():
     return {"message": "Hello world!"}, HTTPStatus.OK
+
+
+dictConfig(
+    {
+        "version": 1,
+        "formatters": {
+            "default": {
+                "format": "[%(asctime)s] (%(levelname)s) %(module)s: %(message)s",  # noqa: E501
+            }
+        },
+        "handlers": {
+            "wsgi": {
+                "class": "logging.StreamHandler",
+                "stream": "ext://flask.logging.wsgi_errors_stream",
+                "formatter": "default",
+            }
+        },
+        "root": {"level": "INFO", "handlers": ["wsgi"]},
+    }
+)

--- a/server/tabby_server/__main__.py
+++ b/server/tabby_server/__main__.py
@@ -1,6 +1,5 @@
 from tabby_server import app
 import os
-from logging.config import dictConfig
 
 
 PORT = os.getenv("PORT", "8000")
@@ -9,25 +8,6 @@ PORT = os.getenv("PORT", "8000")
 if __name__ == "__main__":
 
     # Adapted from tutorial: https://flask.palletsprojects.com/en/stable/logging/  # noqa: E501
-    dictConfig(
-        {
-            "version": 1,
-            "formatters": {
-                "default": {
-                    "format": "[%(asctime)s] (%(levelname)s) %(module)s: %(message)s",  # noqa: E501
-                }
-            },
-            "handlers": {
-                "wsgi": {
-                    "class": "logging.StreamHandler",
-                    "stream": "ext://flask.logging.wsgi_errors_stream",
-                    "formatter": "default",
-                }
-            },
-            "root": {"level": "INFO", "handlers": ["wsgi"]},
-        }
-    )
-
     app.run(debug=False, host="0.0.0.0", port=int(PORT))
 
 # Run by using

--- a/server/tabby_server/api/books.py
+++ b/server/tabby_server/api/books.py
@@ -68,6 +68,9 @@ def books_scan_cover():
 
     current_app.logger.info(f"{G}START       /scan_shelf{RESET}")
 
+    # Get param
+    use_google_books: bool = not ("nosearch" in request.args)
+
     # Try scan image
     with logging_duration("Read image"):
         try:
@@ -84,7 +87,9 @@ def books_scan_cover():
     # ai-gen end
 
     # Scan cover
-    books, (title, author) = scan_cover(img_mat)
+    books, (title, author) = scan_cover(
+        img_mat, use_google_books=use_google_books
+    )
 
     # Filter out books without ISBNs
     if _FILTER_ISBN:
@@ -144,10 +149,9 @@ def scan_cover(
         return [], ("", "")
 
     # Make the request to Google Books
+    top_option = extraction_result.options[0]
     if use_google_books:
         with logging_duration("Request info from Google Books"):
-            top_option = extraction_result.options[0]
-
             title = remove_punctuation(top_option.title).lower()
             author = remove_punctuation(top_option.title).lower()
 
@@ -279,6 +283,9 @@ def books_scan_shelf() -> tuple[dict, HTTPStatus]:
     """
     current_app.logger.info(f"{G}START       /scan_shelf{RESET}")
 
+    # Get param
+    use_google_books: bool = not ("nosearch" in request.args)
+
     # Load image
     with logging_duration("Read image"):
         try:
@@ -295,7 +302,9 @@ def books_scan_shelf() -> tuple[dict, HTTPStatus]:
     # ai-gen end
 
     # scan shelf
-    scanned_shelf, titles_authors = scan_shelf(img_mat)
+    scanned_shelf, titles_authors = scan_shelf(
+        img_mat, use_google_books=use_google_books
+    )
 
     # filter out any books without ISBNs
     # and limit each sublist to a maximum number of books
@@ -388,6 +397,9 @@ def scan_shelf(
             )
             shelf.append(books)
             titles_authors.append((title, author))
+
+    if not use_google_books:
+        shelf = []
 
     return shelf, titles_authors
 

--- a/server/tabby_server/api/books.py
+++ b/server/tabby_server/api/books.py
@@ -107,8 +107,8 @@ def scan_cover(
     Args:
         image_matrix: Image to scan.
     Returns:
-        (1) List of book information scanned. Empty if there is a failure at any
-        part.
+        (1) List of book information scanned. Empty if there is a failure at
+        any part.
         (2) Title and author tuple. Empty strings if failure.
     """
 

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -209,6 +209,26 @@ class TestAPIEndpoint:
                 == 0
             )
 
+            # Test without searching
+            response = client.post(
+                "/books/scan_cover?nosearch", data=BytesIO(image_bytes)
+            )
+
+            logging.info(response.json)
+            assert response.status_code == HTTPStatus.OK
+            assert response.json is not None
+            assert "message" in response.json
+            assert "results" in response.json
+            assert "title" in response.json
+            assert "author" in response.json
+            assert "results" in response.json
+            assert response.json["results"] == []
+            assert (
+                response.json["title"]
+                == "KICKING AWAY THE LADDER: DEVELOPMENT STRATEGY IN HISTORICAL PERSPECTIVE"  # noqa: E501
+            )
+            assert response.json["author"] == "HA-JOON CHANG"
+
         # Test success
         with requests_mock.Mocker() as m:
             google_books_url = "https://www.googleapis.com/books/v1/volumes"
@@ -391,6 +411,25 @@ class TestAPIEndpoint:
                 == len(response.json["results"])
                 == 0
             )
+
+            # Test without searching
+            response = client.post(
+                "/books/scan_shelf?nosearch", data=BytesIO(image_bytes)
+            )
+
+            kicking_title = "KICKING AWAY THE LADDER: DEVELOPMENT STRATEGY IN HISTORICAL PERSPECTIVE"  # noqa: E501
+
+            logging.info(response.json)
+            assert response.status_code == HTTPStatus.OK
+            assert response.json is not None
+            assert "message" in response.json
+            assert "results" in response.json
+            assert "titles" in response.json
+            assert "authors" in response.json
+            assert "results" in response.json
+            assert response.json["results"] == []
+            assert response.json["titles"] == [kicking_title] * 2
+            assert response.json["authors"] == ["HA-JOON CHANG"] * 2
 
         # Test success
         with requests_mock.Mocker() as m:


### PR DESCRIPTION
# Pull Request Template

## Description

<!-- Please include a summary of the changes and the related issue. -->

This is one step in solving #96. This makes the following changes:

- Add `"title"` and `"author"` attribute to /scan_cover endpoint. These are strings, which are the title and author recognized from the image.
- Add `"titles"` and `"authors"` attribute to /scan_shelf endpoint. These are arrays of strings, which are the titles and authors recognized from the image.
- Add `nosearch` parameter to /scan_cover and /scan_shelf endpoints. When given any value, it disables Google Books, making the resulting `"results"` array empty.
- Server API documentation update

So, on the front-end, after using /scan_cover or /scan_shelf we could invoke the /search endpoint **on the US server instead of the Frankfort server** with the title and authors from the response. If you are going to use this approach, make sure to specify `nosearch=1`, so we don't waste an API call.

## Type of Change

- [ ] Bugfix
- [X] New Feature
- [ ] Documentation Update
- [ ] Other (please describe):

## Checklist

- [X] I have read the contributing guidelines.
- [X] I have followed the code style of this project.
- [X] I have added tests to cover my changes.
- [X] I have updated the documentation (if applicable).
- [X] My changes do not generate new warnings.

## Related Issue

#96
<!-- Link to the issue this PR addresses (e.g., #123) -->

## Additional Notes

<!-- Any other information or context relevant to the PR -->
