### PR TITLE
updating favorites page and book page to not have undefined category

### DIFF
--- a/Tabby/app/__tests__/Favorite_Test.js
+++ b/Tabby/app/__tests__/Favorite_Test.js
@@ -3,7 +3,7 @@ import FooterNavBar from '@/components/FooterNavBar';
 import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
 import { usePathname, useRouter } from 'expo-router';
 import Favorites from '@/app/favorites';
-import { getAllFavoriteUserBooks, updateUserBook, getAllCategories, addUserBook } from '@/database/databaseOperations';
+import { getAllFavoriteUserBooks, updateUserBook, getAllCategories } from '@/database/databaseOperations';
 
 jest.mock('expo-router', () => {
     const { Pressable } = require('react-native');

--- a/Tabby/app/__tests__/SearchBar_Test.js
+++ b/Tabby/app/__tests__/SearchBar_Test.js
@@ -57,7 +57,7 @@ describe("Favorite tab test favorites page", () => {
         const favoritesPage = render(<Favorites />);
 
         const searchBar = await favoritesPage.findByPlaceholderText(
-            "Search by title, ISBN, or author..."
+            "Search by title, author, genre, or isbn"
         );
 
         fireEvent.changeText(searchBar, "tempText");

--- a/Tabby/app/favorites.tsx
+++ b/Tabby/app/favorites.tsx
@@ -1,6 +1,6 @@
 import BookPreview from '@/components/BookPreview';
 import React, { useState, useEffect } from 'react';
-import { FlatList, Pressable } from 'react-native';
+import { FlatList, Pressable, View, Text } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import FavoriteButtonIcon from '@/components/FavoriteButtonIcon';
 import { SearchBar } from '@rneui/themed';
@@ -38,12 +38,23 @@ const Favorites = () => {
     }
 
     const renderItem = ({ item }: { item: Book }) => {
-        if (item.isFavorite && (search === "" || item.title.toLowerCase().includes(search.toLowerCase()) || item.author.toLowerCase().includes(search.toLowerCase()) || item.isbn?.toLowerCase().includes(search))) {
+        const trimmedSearch = search.trim();
+        const genresAsArray = item.genres?.split(",") || [];
+        const searchAsLowerCase = trimmedSearch.toLowerCase();
+        const filteredStringWithOnlyNumbers = trimmedSearch.replace(/\D/g, '');
+
+        if (item.isFavorite && (search === "" || item.title.toLowerCase().includes(searchAsLowerCase) || item.author.toLowerCase().includes(searchAsLowerCase) || genresAsArray.some((genre) => genre.toLowerCase().includes(searchAsLowerCase)
+            || item.isbn === filteredStringWithOnlyNumbers))) {
             return (
-                <BookPreview
-                    book={item}
-                    button={renderBookButton(item)}
-                />
+
+                <View>
+                    <Text className='text-left text-white font-bold text-lg pl-5 -mb-2'>{item.category}</Text>
+                    <BookPreview
+                        book={item}
+                        button={renderBookButton(item)}
+                    />
+                </View>
+
             )
         }
         return (null);
@@ -55,8 +66,9 @@ const Favorites = () => {
 
     return (
         <SafeAreaView className="flex-1">
-            <SearchBar placeholder="Search by title, ISBN, or author..." onChangeText={updateSearch} value={search} />
+            <SearchBar placeholder="Search by title, author, genre, or isbn" onChangeText={updateSearch} value={search} />
             <FlatList
+                className="pt-1"
                 data={books}
                 keyExtractor={(item) => item.id}
                 renderItem={renderItem}

--- a/Tabby/app/library/[category]/[book].tsx
+++ b/Tabby/app/library/[category]/[book].tsx
@@ -246,7 +246,7 @@ const BookPage = () => {
         <SafeAreaView className="flex-1">
           <View className="flex-row justify-end items-center">
             <Text className="flex-1 text-white text-2xl font-semibold ml-8 mt-2">
-              {category}
+              {currentBook.category}
             </Text>
 
             <Pressable


### PR DESCRIPTION
# Pull Request Template

## Description

<!-- Please include a summary of the changes and the related issue. -->
- the favorites page the books go to a specific book page but also the favorites page can render these book previews so need to set the proper slug from book object when going from favorites 
- also changed the design bit to show the category they are in

## Type of Change

- [ x] Bugfix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Other (please describe):

## Checklist

- [x ] I have read the contributing guidelines.
- [x ] I have followed the code style of this project.
- [x ] I have added tests to cover my changes.
- [ x] I have updated the documentation (if applicable).
- [ x] My changes do not generate new warnings.

## Related Issue

<!-- Link to the issue this PR addresses (e.g., #123) -->

## Additional Notes

<!-- Any other information or context relevant to the PR -->
