### PR TITLE
putting text and back button in a safe area view to avoid it covering…

### DIFF
--- a/Tabby/app/_layout.tsx
+++ b/Tabby/app/_layout.tsx
@@ -9,6 +9,7 @@ import { NativeWindStyleSheet } from "nativewind";
 import LoadingSpinner from '@/components/LoadingSpinner';
 import { migrateDbIfNeeded } from '@/database/migration';
 import ArrowBackIcon from '@/assets/menu-icons/arrow-back-icon.svg';
+import { SafeAreaView } from "react-native-safe-area-context";
 
 // Configure nativewind for web compatibility
 NativeWindStyleSheet.setOutput({
@@ -31,10 +32,12 @@ function BackButton() {
     const router = useRouter();
 
     return (
+
         <Pressable onPress={() => router.back()} className='p-2'>
             <ArrowBackIcon height={36} width={36} />
         </Pressable>
     );
+
 }
 
 export default function RootLayout() {
@@ -48,10 +51,10 @@ export default function RootLayout() {
                     <SQLiteProvider databaseName="bookCollection.db" onInit={migrateDbIfNeeded} useSuspense >
                         <ContentContainer testID="ContentContainer">
                             {!isWelcomePage && (
-                                <View className='flex-row justify-start items-center space-x-5'>
+                                <SafeAreaView className='flex-row justify-start items-center space-x-5'>
                                     <BackButton />
                                     <Text className="text-white text-2xl font-bold">Tabby</Text>
-                                </View>
+                                </SafeAreaView>
                             )}
                             <Slot />
                         </ContentContainer>


### PR DESCRIPTION
top of phone on ios back button cover the time, wifi, stuff

# Pull Request Template

## Description

<!-- Please include a summary of the changes and the related issue. -->
- on ios back button with text it would cover top of screen due to not being in a safe area view
- put it in safe area view but need confirmation that it is fixed

## Type of Change

- [ x] Bugfix
- [ ] New Feature
- [ ] Documentation Update
- [ ] Other (please describe):

## Checklist

- [ x] I have read the contributing guidelines.
- [ x] I have followed the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if applicable).
- [ x] My changes do not generate new warnings.

## Related Issue

<!-- Link to the issue this PR addresses (e.g., #123) -->

## Additional Notes

<!-- Any other information or context relevant to the PR -->
